### PR TITLE
Fix example path to correctly remove CATKIN_IGNORE file

### DIFF
--- a/agentos_examples/CMakeLists.txt
+++ b/agentos_examples/CMakeLists.txt
@@ -12,25 +12,26 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(JSONCPP jsoncpp)
+pkg_check_modules(JSONCPP REQUIRED   ${JSONCPP_LIBRARIES})
 
 catkin_package()
 
 include_directories(
   ${catkin_INCLUDE_DIRS}
+  ${JSONCPP_INCLUDE_DIRS}
 )
 
 add_executable(hold_skill_node cplusplus/hold_skill.cpp)
-target_link_libraries(hold_skill_node ${catkin_LIBRARIES} jsoncpp)
+target_link_libraries(hold_skill_node ${catkin_LIBRARIES}   ${JSONCPP_LIBRARIES})
 
 add_executable(invoke_skill_node cplusplus/invoke_skill.cpp)
-target_link_libraries(invoke_skill_node ${catkin_LIBRARIES} jsoncpp)
+target_link_libraries(invoke_skill_node ${catkin_LIBRARIES}   ${JSONCPP_LIBRARIES})
 
 add_executable(skill_contrl_node cplusplus/skill_contrl.cpp)
-target_link_libraries(skill_contrl_node ${catkin_LIBRARIES} jsoncpp)
+target_link_libraries(skill_contrl_node ${catkin_LIBRARIES}   ${JSONCPP_LIBRARIES})
 
 add_executable(skill_status_node cplusplus/skill_status.cpp)
-target_link_libraries(skill_status_node ${catkin_LIBRARIES} jsoncpp)
+target_link_libraries(skill_status_node ${catkin_LIBRARIES}   ${JSONCPP_LIBRARIES})
 
 catkin_install_python(PROGRAMS
   python/hold_skill.py

--- a/agentos_examples/README.md
+++ b/agentos_examples/README.md
@@ -1,7 +1,8 @@
 #### Depends
 
 ```bash
-sudo apt install libjsoncpp-dev
+sudo apt install libjsoncpp-dev #For Ubuntu/Debian systems
+brew install jsoncpp #For macOS systems
 ```
 
 #### Compile

--- a/agentos_examples/README.md
+++ b/agentos_examples/README.md
@@ -8,12 +8,11 @@ sudo apt install libjsoncpp-dev
 
 ```bash
 cd ~/agent_ws
-rm src/agentos_sdk/agentos_examples/CATKIN_IGNORE
+rm src/agentos_examples/CATKIN_IGNORE
 catkin build
 ```
 
 #### Run
-
 
 ```bash
 source devel/setup.bash

--- a/agentos_examples/cplusplus/invoke_skill.cpp
+++ b/agentos_examples/cplusplus/invoke_skill.cpp
@@ -1,7 +1,7 @@
 #include <ros/ros.h>
 #include <actionlib/client/simple_action_client.h>
 #include <agent_msgs/ExecuteAction.h>
-#include <jsoncpp/json/json.h> // Include jsoncpp library
+#include <json/json.h> // Include jsoncpp library
 
 // Feedback callback function
 void feedbackCallback(const agent_msgs::ExecuteFeedbackConstPtr &feedback)


### PR DESCRIPTION
Correct the path for removing the CATKIN_IGNORE file in the agentos_examples directory.